### PR TITLE
chore: enable Sonar and deployment to Maven Central

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -63,9 +63,9 @@ jobs:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ -n "${GITHUB_HEAD_REF}" ]; then
-            mvn --batch-mode -s "${SETTINGS_XML}" clean verify  # sonar:sonar -Dsonar.branch.name="${GITHUB_HEAD_REF}"
+            mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.branch.name="${GITHUB_HEAD_REF}"
           else
-            mvn --batch-mode -s "${SETTINGS_XML}" clean verify  # sonar:sonar
+            mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar
           fi
       - name: 📦 Build with Maven for PRs
         if: github.event_name == 'pull_request'
@@ -73,7 +73,7 @@ jobs:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_PR_NUMBER_REF: ${{ github.event.pull_request.number }}
-        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify  # sonar:sonar -Dsonar.pullrequest.base="${GITHUB_BASE_REF}" -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
+        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.pullrequest.base="${GITHUB_BASE_REF}" -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
       - name: 📋 Analyze dependencies
         run: mvn --batch-mode -s "${SETTINGS_XML}" dependency:analyze
         continue-on-error: false
@@ -123,8 +123,7 @@ jobs:
             -P central-publishing \
             -Dcentral.timeout=3600 \
             -Dmaven.wagon.http.connectionTimeout=3600000 \
-            -Dmaven.wagon.http.readTimeout=3600000 \
-            -Dcentral-publishing-maven-plugin.autoPublish=false
+            -Dmaven.wagon.http.readTimeout=3600000
   deploy-github-packages:
     needs: build
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -157,7 +156,7 @@ jobs:
       - name: 📦 Deploy to GitHub Packages
         # Releases should only be deployed to GitHub packages when the repo is private
         # Only snapshots should always be deployed here
-        # if: ${{ needs.build.outputs.is_release == 'false' }}  # Comment out when the repository is public
+        if: ${{ needs.build.outputs.is_release == 'false' }}
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" deploy \
             -Dmaven.test.skip=true \


### PR DESCRIPTION
### Proposed changes

This pull request updates the Maven build workflow in `.github/workflows/maven-build.yml` to enable integration with SonarQube, streamline configuration, and adjust deployment conditions. Below are the most important changes grouped by theme:

### SonarQube Integration:
* Enabled SonarQube analysis for all Maven build steps by removing comments and adding the `sonar:sonar` goal with appropriate parameters, ensuring code quality checks are consistently applied.

### Configuration Simplification:
* Removed the `central-publishing-maven-plugin.autoPublish` parameter from the Maven command, simplifying the configuration for central publishing.

### Deployment Conditions:
* Uncommented the conditional check for deploying releases to GitHub Packages, ensuring that only non-release builds are deployed when the repository is private.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
